### PR TITLE
add patch to support AER plan formats

### DIFF
--- a/energy/aer.patch
+++ b/energy/aer.patch
@@ -1,0 +1,31 @@
+diff --git a/energy/energy.gen.go b/energy/energy.gen.go
+index f39d2ee..cedd8e5 100644
+--- a/energy/energy.gen.go
++++ b/energy/energy.gen.go
+@@ -1962,7 +1962,7 @@ type EnergyPlanContractFullV2 struct {
+ 	ControlledLoad *EnergyPlanControlledLoad `json:"controlledLoad,omitempty"`
+ 
+ 	// CoolingOffDays Number of days in the cooling off period for the contract.  Mandatory for plans with type of MARKET
+-	CoolingOffDays *int `json:"coolingOffDays,omitempty"`
++	CoolingOffDays *PatchedCoolingOffDays `json:"coolingOffDays,omitempty"`
+ 
+ 	// Discounts Optional list of discounts available for the contract
+ 	Discounts *EnergyPlanDiscounts `json:"discounts,omitempty"`
+@@ -2037,7 +2037,7 @@ type EnergyPlanContractFullV2AllOf struct {
+ 	BillFrequency []string `json:"billFrequency"`
+ 
+ 	// CoolingOffDays Number of days in the cooling off period for the contract.  Mandatory for plans with type of MARKET
+-	CoolingOffDays *int `json:"coolingOffDays,omitempty"`
++	CoolingOffDays *PatchedCoolingOffDays `json:"coolingOffDays,omitempty"`
+ 
+ 	// MeterTypes An array of the meter types that this contract is available for
+ 	MeterTypes *[]string `json:"meterTypes,omitempty"`
+@@ -2574,7 +2574,7 @@ type EnergyPlanTariffPeriod = []struct {
+ 		ChargePeriod EnergyPlanTariffPeriodDemandChargesChargePeriod `json:"chargePeriod"`
+ 
+ 		// Days The days that the demand tariff applies to
+-		Days *[]EnergyPlanTariffPeriodDemandChargesDays `json:"days,omitempty"`
++		Days *PatchedDemandChargesDays `json:"days,omitempty"`
+ 
+ 		// Description Description of the charge
+ 		Description *string `json:"description,omitempty"`

--- a/energy/energy.gen.go
+++ b/energy/energy.gen.go
@@ -1962,7 +1962,7 @@ type EnergyPlanContractFullV2 struct {
 	ControlledLoad *EnergyPlanControlledLoad `json:"controlledLoad,omitempty"`
 
 	// CoolingOffDays Number of days in the cooling off period for the contract.  Mandatory for plans with type of MARKET
-	CoolingOffDays *int `json:"coolingOffDays,omitempty"`
+	CoolingOffDays *PatchedCoolingOffDays `json:"coolingOffDays,omitempty"`
 
 	// Discounts Optional list of discounts available for the contract
 	Discounts *EnergyPlanDiscounts `json:"discounts,omitempty"`
@@ -2037,7 +2037,7 @@ type EnergyPlanContractFullV2AllOf struct {
 	BillFrequency []string `json:"billFrequency"`
 
 	// CoolingOffDays Number of days in the cooling off period for the contract.  Mandatory for plans with type of MARKET
-	CoolingOffDays *int `json:"coolingOffDays,omitempty"`
+	CoolingOffDays *PatchedCoolingOffDays `json:"coolingOffDays,omitempty"`
 
 	// MeterTypes An array of the meter types that this contract is available for
 	MeterTypes *[]string `json:"meterTypes,omitempty"`
@@ -2574,7 +2574,7 @@ type EnergyPlanTariffPeriod = []struct {
 		ChargePeriod EnergyPlanTariffPeriodDemandChargesChargePeriod `json:"chargePeriod"`
 
 		// Days The days that the demand tariff applies to
-		Days *[]EnergyPlanTariffPeriodDemandChargesDays `json:"days,omitempty"`
+		Days *PatchedDemandChargesDays `json:"days,omitempty"`
 
 		// Description Description of the charge
 		Description *string `json:"description,omitempty"`

--- a/energy/patch.go
+++ b/energy/patch.go
@@ -1,0 +1,73 @@
+package energy
+
+import (
+	"encoding/json"
+	"strconv"
+)
+
+// PatchedCoolingOffDays is a type that can unmarshal an int from both a number and a string.
+// issue: https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/582
+type PatchedCoolingOffDays int
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (pc *PatchedCoolingOffDays) UnmarshalJSON(b []byte) error {
+	if b[0] != '"' {
+		return json.Unmarshal(b, (*int)(pc))
+	}
+
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return err
+	}
+
+	*pc = PatchedCoolingOffDays(i)
+	return nil
+}
+
+// PatchedDemandChargesDays is a type that can unmarshal from new enum format and also from old format
+// issue: https://github.com/ConsumerDataStandardsAustralia/standards-maintenance/issues/502
+type PatchedDemandChargesDays []EnergyPlanTariffPeriodDemandChargesDays
+
+type oldDemandChargesDays struct {
+	Weekdays bool `json:"weekdays"`
+	Saturday bool `json:"saturday"`
+	Sunday   bool `json:"sunday"`
+}
+
+// UnmarshalJSON implements the json.Unmarshaller interface.
+func (pd *PatchedDemandChargesDays) UnmarshalJSON(b []byte) error {
+	if b[0] == '[' {
+		return json.Unmarshal(b, (*[]EnergyPlanTariffPeriodDemandChargesDays)(pd))
+	}
+
+	var oldDays oldDemandChargesDays
+	if err := json.Unmarshal(b, &oldDays); err != nil {
+		return err
+	}
+
+	var newDays []EnergyPlanTariffPeriodDemandChargesDays = make([]EnergyPlanTariffPeriodDemandChargesDays, 0)
+	if oldDays.Weekdays {
+		newDays = append(newDays,
+			EnergyPlanTariffPeriodDemandChargesDaysMON,
+			EnergyPlanTariffPeriodDemandChargesDaysTUE,
+			EnergyPlanTariffPeriodDemandChargesDaysWED,
+			EnergyPlanTariffPeriodDemandChargesDaysTHU,
+			EnergyPlanTariffPeriodDemandChargesDaysFRI)
+	}
+
+	if oldDays.Saturday {
+		newDays = append(newDays, EnergyPlanTariffPeriodDemandChargesDaysSAT)
+	}
+
+	if oldDays.Sunday {
+		newDays = append(newDays, EnergyPlanTariffPeriodDemandChargesDaysSUN)
+	}
+
+	*pd = newDays
+	return nil
+}

--- a/energy/patch_test.go
+++ b/energy/patch_test.go
@@ -1,0 +1,51 @@
+package energy_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/fiskil/cdr/energy"
+	"github.com/matryer/is"
+)
+
+func TestPatchedCoolingOffDays(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	var i energy.PatchedCoolingOffDays
+
+	// Unmarshal a number.
+	err := json.Unmarshal([]byte("1"), &i)
+	is.NoErr(err)
+	is.Equal(i, energy.PatchedCoolingOffDays(1))
+
+	// Unmarshal a string.
+	err = json.Unmarshal([]byte(`"1"`), &i)
+	is.NoErr(err)
+	is.Equal(i, energy.PatchedCoolingOffDays(1))
+
+	bytes, err := json.Marshal(i)
+	is.NoErr(err)
+	is.Equal(string(bytes), "1")
+}
+
+func TestPatchedDemandChargesDays(t *testing.T) {
+	t.Parallel()
+	is := is.New(t)
+
+	var d energy.PatchedDemandChargesDays
+
+	// Unmarshal from new enum format.
+	err := json.Unmarshal([]byte(`["MON", "TUE", "WED"]`), &d)
+	is.NoErr(err)
+	is.Equal(d, energy.PatchedDemandChargesDays{"MON", "TUE", "WED"})
+
+	// Unmarshal from old format.
+	err = json.Unmarshal([]byte(`{"weekdays": true, "saturday": false, "sunday": false}`), &d)
+	is.NoErr(err)
+	is.Equal(d, energy.PatchedDemandChargesDays{"MON", "TUE", "WED", "THU", "FRI"})
+
+	bytes, err := json.Marshal(d)
+	is.NoErr(err)
+	is.Equal(string(bytes), `["MON","TUE","WED","THU","FRI"]`)
+}


### PR DESCRIPTION
Some of the energy plan response from https://cdr.energymadeeasy.gov.au/ are not compatible with latest CDR standards often results in the following failures. 

```
json: cannot unmarshal object into Go struct field .data.electricityContract.tariffPeriod.demandCharges.days of type []energy.EnergyPlanTariffPeriodDemandChargesDays
json: cannot unmarshal string into Go struct field EnergyPlanContractFullV2.data.electricityContract.coolingOffDays of type int
json: cannot unmarshal string into Go struct field EnergyPlanContractFullV2.data.gasContract.coolingOffDays of type int
```  

The ideal solution is to get AER to update those discrepancy issues and to align with CDR standards, but since we cannot rely on that at the moment, this is a workaround solution. 